### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/git-ftp.py
+++ b/git-ftp.py
@@ -51,7 +51,7 @@ from distutils.version import LooseVersion
 from git import __version__ as git_version
 
 if LooseVersion(git_version) < '0.3.0':
-    print 'git-ftp requires git-python 0.3.0 or newer; %s provided.' % git_version
+    print 'git-ftp requires git-python 0.3.0 or newer; {0!s} provided.'.format(git_version)
     exit(1)
 
 from git import Blob, Repo, Git, Submodule
@@ -242,7 +242,7 @@ def configure_logging(options):
 
 
 def format_mode(mode):
-    return "%o" % (mode & 0o777)
+    return "{0:o}".format((mode & 0o777))
 
 
 class FtpData():
@@ -286,7 +286,7 @@ def get_ftp_creds(repo, options):
                                         "Take a look at the README for more information")
             else:
                 raise SectionNotFound("Your .git/ftpdata file does not contain a section " +
-                                     "named '%s'" % options.section)
+                                     "named '{0!s}'".format(options.section))
 
         # just in case you do not want to store your ftp password.
         try:
@@ -307,7 +307,7 @@ def get_ftp_creds(repo, options):
         except ConfigParser.NoOptionError:
             options.ftp.gitftpignore = '.gitftpignore'
     else:
-        print "Please configure settings for branch '%s'" % options.section
+        print "Please configure settings for branch '{0!s}'".format(options.section)
         options.ftp.username = raw_input('FTP Username: ')
         options.ftp.password = getpass.getpass('FTP Password: ')
         options.ftp.hostname = raw_input('FTP Hostname: ')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:git-ftp?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:git-ftp?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
